### PR TITLE
Add Profiled for GitHub to the list of GitHub tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ The rest is pretty cool too, but these deserve a special place :)
 
 #### :octocat: Github Tools
  - [Refined GitHub](https://chrome.google.com/webstore/detail/hlepfoohegkhhmjieoechaddaejaokhf)
+ - [Profiled for GitHub](https://chrome.google.com/webstore/detail/profiled-for-github/gliklioolkfpkcgjfkobfgcgolliahll) - Find a GitHub user's social profiles and add them to the page
  - [OctoHR](https://chrome.google.com/webstore/detail/beiklbdjdmfkgchmiabjejdlpaoicbef)
  - [GitHub Hovercard](https://chrome.google.com/webstore/detail/mmoahbbnojgkclgceahhakhnccimnplk)
  - [CoderStats link for Github Coders](https://chrome.google.com/webstore/detail/necogepejonacpphmlmcagmbjaogpbng)

--- a/README.md
+++ b/README.md
@@ -296,11 +296,11 @@ The rest is pretty cool too, but these deserve a special place :)
 
 #### :octocat: Github Tools
  - [Refined GitHub](https://chrome.google.com/webstore/detail/hlepfoohegkhhmjieoechaddaejaokhf)
- - [Profiled for GitHub](https://chrome.google.com/webstore/detail/profiled-for-github/gliklioolkfpkcgjfkobfgcgolliahll) - Find a GitHub user's social profiles and add them to the page
  - [OctoHR](https://chrome.google.com/webstore/detail/beiklbdjdmfkgchmiabjejdlpaoicbef)
  - [GitHub Hovercard](https://chrome.google.com/webstore/detail/mmoahbbnojgkclgceahhakhnccimnplk)
  - [CoderStats link for Github Coders](https://chrome.google.com/webstore/detail/necogepejonacpphmlmcagmbjaogpbng)
  - [Github User Rank](https://chrome.google.com/webstore/detail/oabhkjmpcnkeifhahnlhafajeoofhjak)
+ - [Profiled for GitHub](https://chrome.google.com/webstore/detail/profiled-for-github/gliklioolkfpkcgjfkobfgcgolliahll) - Find a GitHub user's social profiles.
 
 #### 🙋 Job Description Tools
  - [Textio](https://textio.com/) 💰


### PR DESCRIPTION
This extension finds Twitter, Reddit and Hacker News profiles for a GitHub user where available and inserts them into the page.