### PR TITLE
Add FreshActors ATS job scrapers (Greenhouse/Lever/Workable/SmartRecruiters/Recruitee)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ The rest is pretty cool too, but these deserve a special place :)
  - [Public-APIs list ](https://github.com/toddmotto/public-apis)
  - [Postman Interceptor](https://chrome.google.com/webstore/detail/postman-interceptor/aicmkgpgakddgnaphhhpliifpcfhicfo?hl=en)
  - [Scrapy](https://scrapy.org/)
+ - [FreshActors ATS Job Scrapers](https://apify.com/freshactors) - Live job postings from Greenhouse, Lever, Workable, SmartRecruiters & Recruitee boards as normalized JSON — no API key. 💰
 
 #### :octocat: Github Tools
  - [Refined GitHub](https://chrome.google.com/webstore/detail/hlepfoohegkhhmjieoechaddaejaokhf)


### PR DESCRIPTION
This adds the **FreshActors ATS job scrapers** under 🛠️ Recruitment Tools → 🐿 Scraping.

They extract live job postings from **Greenhouse, Lever, Workable, SmartRecruiters, and Recruitee** company boards into one normalized JSON schema (title, location, department, full description, salary where posted, apply URL) — no API key or login. Handy for sourcing, hiring-signal tracking, and compensation benchmarking.

- All scrapers / profile: https://apify.com/freshactors

Thanks for maintaining this list! 🙏